### PR TITLE
Pin numpy dependency below 1.24 to work with the older tensorflow version

### DIFF
--- a/conda_env.yml
+++ b/conda_env.yml
@@ -8,3 +8,4 @@ dependencies:
   - scikit-learn=1.0.1
   - tensorflow=2.6.0
   - keras=2.6.0
+  - numpy<1.24.0

--- a/conda_env_gpu.yml
+++ b/conda_env_gpu.yml
@@ -8,3 +8,4 @@ dependencies:
   - scikit-learn=1.0.1
   - tensorflow-gpu=2.6.0
   - keras-gpu=2.6.0
+  - numpy<1.24.0


### PR DESCRIPTION
Conda will resolve numpy to a relatively recent version (1.26.x in my case), causing problems with the older pinned tensorflow version:
```
C:\Users\Tobias\miniconda3\envs\BCA\lib\site-packages\tensorflow\python\framework\dtypes.py:585: FutureWarning: In the future `np.object` will be defined as the corresponding NumPy scalar.
  np.object,
Traceback (most recent call last):
  File "C:\Users\Tobias\Desktop\test\Machine-learning-for-prediction-of-BCFAs\predict.py", line 8, in <module>
    from keras.models import load_model
  File "C:\Users\Tobias\miniconda3\envs\BCA\lib\site-packages\keras\__init__.py", line 21, in <module>
    from tensorflow.python import tf2
  File "C:\Users\Tobias\miniconda3\envs\BCA\lib\site-packages\tensorflow\__init__.py", line 41, in <module>
    from tensorflow.python.tools import module_util as _module_util
  File "C:\Users\Tobias\miniconda3\envs\BCA\lib\site-packages\tensorflow\python\__init__.py", line 46, in <module>
    from tensorflow.python import data
  File "C:\Users\Tobias\miniconda3\envs\BCA\lib\site-packages\tensorflow\python\data\__init__.py", line 25, in <module>
    from tensorflow.python.data import experimental
  File "C:\Users\Tobias\miniconda3\envs\BCA\lib\site-packages\tensorflow\python\data\experimental\__init__.py", line 97, in <module>
    from tensorflow.python.data.experimental import service
  File "C:\Users\Tobias\miniconda3\envs\BCA\lib\site-packages\tensorflow\python\data\experimental\service\__init__.py", line 353, in <module>
    from tensorflow.python.data.experimental.ops.data_service_ops import distribute
  File "C:\Users\Tobias\miniconda3\envs\BCA\lib\site-packages\tensorflow\python\data\experimental\ops\data_service_ops.py", line 26, in <module>
    from tensorflow.python.data.experimental.ops import compression_ops
  File "C:\Users\Tobias\miniconda3\envs\BCA\lib\site-packages\tensorflow\python\data\experimental\ops\compression_ops.py", line 20, in <module>
    from tensorflow.python.data.util import structure
  File "C:\Users\Tobias\miniconda3\envs\BCA\lib\site-packages\tensorflow\python\data\util\structure.py", line 26, in <module>
    from tensorflow.python.data.util import nest
  File "C:\Users\Tobias\miniconda3\envs\BCA\lib\site-packages\tensorflow\python\data\util\nest.py", line 40, in <module>
    from tensorflow.python.framework import sparse_tensor as _sparse_tensor
  File "C:\Users\Tobias\miniconda3\envs\BCA\lib\site-packages\tensorflow\python\framework\sparse_tensor.py", line 28, in <module>
    from tensorflow.python.framework import constant_op
  File "C:\Users\Tobias\miniconda3\envs\BCA\lib\site-packages\tensorflow\python\framework\constant_op.py", line 29, in <module>
    from tensorflow.python.eager import execute
  File "C:\Users\Tobias\miniconda3\envs\BCA\lib\site-packages\tensorflow\python\eager\execute.py", line 27, in <module>
    from tensorflow.python.framework import dtypes
  File "C:\Users\Tobias\miniconda3\envs\BCA\lib\site-packages\tensorflow\python\framework\dtypes.py", line 585, in <module>
    np.object,
  File "C:\Users\Tobias\miniconda3\envs\BCA\lib\site-packages\numpy\__init__.py", line 324, in __getattr__
    raise AttributeError(__former_attrs__[attr])
AttributeError: module 'numpy' has no attribute 'object'.
`np.object` was a deprecated alias for the builtin `object`. To avoid this error in existing code, use `object` by itself. Doing this will not modify any behavior and is safe.
The aliases was originally deprecated in NumPy 1.20; for more details and guidance see the original release note at:
    https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
```

`numpy.object` was removed in 1.24 (see https://numpy.org/devdocs/release/1.24.0-notes.html), so we should probably pin numpy to a version below 1.24.